### PR TITLE
Datetime input format

### DIFF
--- a/mpvaGetArchived.m
+++ b/mpvaGetArchived.m
@@ -93,14 +93,12 @@ end
 
 function [start_str, end_str] = local2utc(starttime, endtime)
     % Return timestamp as a string in UTC in ISO 8601 format
-    infmt = 'mm/dd/yyyy hh:mm:ss';
-    
-    starttime = datetime(starttime, 'InputFormat', infmt, 'TimeZone', 'America/Los_Angeles');
+    starttime = datetime(starttime, 'TimeZone', 'America/Los_Angeles');
     starttime.TimeZone = 'UTC';
     starttime.Format = 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z';
     start_str = string(starttime);
     
-    endtime = datetime(endtime, 'InputFormat', infmt, 'TimeZone', 'America/Los_Angeles');
+    endtime = datetime(endtime, 'TimeZone', 'America/Los_Angeles');
     endtime.TimeZone = 'UTC';
     endtime.Format = 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z';
     end_str = string(endtime);

--- a/mpvaGetArchived.m
+++ b/mpvaGetArchived.m
@@ -5,9 +5,9 @@ function varargout = mpvaGetArchived(pvname, starttime, endtime)
 %    [NTTable, ts, alarm, NTStruct] = mpvaGetArchived(pvname, starttime, endtime)
 %
 %    starttime: Beginning time as a datetime object or a string in
-%                   format 'mm/dd/yyyy hh:mm:ss' or standard matlab date formats
+%                   format 'mm/dd/yyyy hh:mm:ss'
 %    endtime:   Ending time as a datetime object or a string in
-%                   format 'mm/dd/yyyy hh:mm:ss' or standard matlab date formats
+%                   format 'mm/dd/yyyy hh:mm:ss'
 %
 
 % -----------------------------------------------------------------------------
@@ -93,12 +93,14 @@ end
 
 function [start_str, end_str] = local2utc(starttime, endtime)
     % Return timestamp as a string in UTC in ISO 8601 format
-    starttime = datetime(starttime, 'TimeZone', 'America/Los_Angeles');
+    infmt = 'MM/dd/yyyy HH:mm:ss';
+
+    starttime = datetime(starttime, 'InputFormat', infmt, 'TimeZone', 'America/Los_Angeles');
     starttime.TimeZone = 'UTC';
     starttime.Format = 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z';
     start_str = string(starttime);
     
-    endtime = datetime(endtime, 'TimeZone', 'America/Los_Angeles');
+    endtime = datetime(endtime, 'InputFormat', infmt, 'TimeZone', 'America/Los_Angeles');
     endtime.TimeZone = 'UTC';
     endtime.Format = 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z';
     end_str = string(endtime);


### PR DESCRIPTION
Removing the datetime InputFormat as it was incorrect. The default datetime input behavior works perfectly and should be used instead.